### PR TITLE
Release 1.1.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,22 @@
 # Change Log
 
+## 1.1.0 (Sep 7, 2023)
+### Sendbird Live SDK is now out of beta. 
+
+### Introducing Audio Only Live Events. 
+You can stream live events with audio only, without having to turn the video on. 
+- Added `hostType` to `LiveEvent`
+    - singleHost: live event in which one host can stream video and audio at a time. 
+    - singleHostAudioOnly: live event in which one host can stream only audio at a time. 
+    - When creating or retrieving a list of live events, you must specify the type of the live event by providing a `hostType` variable. 
+- Added `hostType` to `LiveEvent.CreateParams`
+- Added `hostTypes` to `LiveEventListQueryParams
+
+### Breaking Changes
+- `LiveEvent.didParticipantEnter` and `LiveEvent.didParticipantExit` have been removed due to the excessive number of events they triggered when numerous participants joined the live event
+    - Instead, use `LiveEvent.didParticipantCountChanged` to track the change of participant counts in a live event. This event will not be called every time a new participant joins the live event. Instead, it will be called periodically depending on the total number of participants joining the live event.
+- Now, initializing the Live SDK will initialize Sendbird Chat SDK, using the default `InitParams` defined in the Chat SDK. If you wish to change the initialization parameters of the Chat SDK, you must call `SendbirdChat.initialize` again after the Live SDK initialization. 
+
 ## 1.0.0-beta.15 (Aug 25, 2023)
 - Stability improvements. 
 

--- a/Package.swift
+++ b/Package.swift
@@ -11,13 +11,13 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/sendbird/sendbird-webrtc-ios", from: "1.7.0"),
-        .package(url: "https://github.com/sendbird/sendbird-chat-sdk-ios", from: "4.9.5")
+        .package(url: "https://github.com/sendbird/sendbird-chat-sdk-ios", from: "4.11.0")
     ],
     targets: [
         .binaryTarget(
             name: "SendbirdLiveSDK",
-            url: "https://github.com/sendbird/sendbird-live-sdk-ios/releases/download/v1.0.0-beta.15/SendbirdLiveSDK.xcframework.zip",
-            checksum: "32a3dd520467a91f7d0f7b5dc0e66aba61c0b24a41ff2d85659a0128dc253d8e"
+            url: "https://github.com/sendbird/sendbird-live-sdk-ios/releases/download/v1.1.0/SendbirdLiveSDK.xcframework.zip",
+            checksum: "5fa58c88003ffaab12175f18bce64a5572b6f6d79167637f615869833444de74"
         ),
         .target(name: "SendbirdLiveSDKTarget",
                 dependencies: [

--- a/SendbirdLiveSDK.podspec
+++ b/SendbirdLiveSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'SendbirdLiveSDK'
-  s.version      = "1.0.0-beta.15"
+  s.version      = "1.1.0"
   s.summary      = 'Sendbird Live iOS Framework'
   s.description  = 'Sendbird Live API turns a client app into a live streaming platform where users can broadcast themselves in real-time to their followers.'
   s.homepage     = 'https://sendbird.com'
@@ -15,13 +15,13 @@ Pod::Spec.new do |s|
     'Celine Moon' => 'celine.moon@sendbird.com',
     'Young Hwang' => 'young.hwang@sendbird.com'
   }
-  s.source       = { :http => "https://github.com/sendbird/sendbird-live-sdk-ios/releases/download/v1.0.0-beta.15/SendbirdLiveSDK.zip", :sha1 => "f0016060531421ef37a884d514e6a08fb70d7686" }
+  s.source       = { :http => "https://github.com/sendbird/sendbird-live-sdk-ios/releases/download/v1.1.0/SendbirdLiveSDK.zip", :sha1 => "fa09c5dcbd6368600ba415587feb6f052a015cfe" }
   s.requires_arc = true
   s.platform = :ios, '11.0'
   s.documentation_url = 'https://sendbird.com/docs/live/v1/ios/ref/index.html'
   s.ios.vendored_frameworks = 'SendbirdLiveSDK/SendbirdLiveSDK.xcframework'
   s.dependency "SendBirdWebRTC", "~> 1.7.0"
-  s.dependency "SendbirdChatSDK", "~> 4.9.5"
+  s.dependency "SendbirdChatSDK", "~> 4.11.0"
   s.ios.frameworks =  ["UIKit", "Foundation", "WebRTC", "AVKit", "MediaPlayer", "Network", "CoreTelephony", "VideoToolbox"]
   s.ios.library   = 'icucore'
 end


### PR DESCRIPTION
# 1.1.0 (Sep 7, 2023)

## Sendbird Live SDK is now out of beta. 

## Introducing Audio Only Live Events. 
You can stream live events with audio only, without having to turn the video on. 
- Added `hostType` to `LiveEvent`
    - singleHost: live event in which one host can stream video and audio at a time. 
    - singleHostAudioOnly: live event in which one host can stream only audio at a time. 
    - When creating or retrieving a list of live events, you must specify the type of the live event by providing a `hostType` variable. 
- Added `hostType` to `LiveEvent.CreateParams`
- Added `hostTypes` to `LiveEventListQueryParams

## Breaking Changes
- `LiveEvent.didParticipantEnter` and `LiveEvent.didParticipantExit` have been removed due to the excessive number of events they triggered when numerous participants joined the live event
    - Instead, use `LiveEvent.didParticipantCountChanged` to track the change of participant counts in a live event. This event will not be called every time a new participant joins the live event. Instead, it will be called periodically depending on the total number of participants joining the live event.
- Now, initializing the Live SDK will initialize Sendbird Chat SDK, using the default `InitParams` defined in the Chat SDK. If you wish to change the initialization parameters of the Chat SDK, you must call `SendbirdChat.initialize` again after the Live SDK initialization. 
- *JS Specific* `LiveEvent.setVideoViewForLiveEvent()` is replaced with `LiveEvent.setMediaViewForLiveEvent()`.