### PR TITLE
Release 1.2.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## 1.2.0 (Dec 2, 2023)
+- Added support for streaming with multiple hosts
+    - Now, multiple hosts can stream in a live event simultaneously. 
+    - `LiveEvent.hostType` has changed to `LiveEvent.type`
+    - LiveEventType can have following values: `audioOnly` and `video`, indicating the live event type for audio-only streaming and video streaming, respectively. 
+    - `LiveEventCreateParams.hostType` has changed to `LiveEventCreateParams.type`
+    - `LiveEventQuery.hostTypes` has changed to `LiveEventQuery.types`
+- Added event listeners for receiving connection
+    - LiveEventDelegate.didDisconnect(liveEvent: LiveEvent, e: Error)
+    - LiveEventDelegate.didReconnect(liveEvent: LiveEvent)
+- The existing `didDisconnect` event is now renamed to `LiveEventDelegate.didExit(liveEvent: LiveEvent, e: Error)`
+
 ## 1.2.0-beta.1 (Nov 8, 2023)
 - Added support for streaming with multiple hosts
     - Now, multiple hosts can stream in a live event simultaneously. 

--- a/Package.swift
+++ b/Package.swift
@@ -16,8 +16,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "SendbirdLiveSDK",
-            url: "https://github.com/sendbird/sendbird-live-sdk-ios/releases/download/v1.2.0-beta.1/SendbirdLiveSDK.xcframework.zip",
-            checksum: "001876a7c4650cb8a6952358f15383b33e5a3eba3c67235448a58588bf3ebb28"
+            url: "https://github.com/sendbird/sendbird-live-sdk-ios/releases/download/v1.2.0/SendbirdLiveSDK.xcframework.zip",
+            checksum: "88e13d49d75a6ddc13fbab4ab564310093cf840381a7cbdfdb60f6fb9711cb61"
         ),
         .target(name: "SendbirdLiveSDKTarget",
                 dependencies: [

--- a/SendbirdLiveSDK.podspec
+++ b/SendbirdLiveSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'SendbirdLiveSDK'
-  s.version      = "1.2.0-beta.1"
+  s.version      = "1.2.0"
   s.summary      = 'Sendbird Live iOS Framework'
   s.description  = 'Sendbird Live API turns a client app into a live streaming platform where users can broadcast themselves in real-time to their followers.'
   s.homepage     = 'https://sendbird.com'
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
     'Celine Moon' => 'celine.moon@sendbird.com',
     'Young Hwang' => 'young.hwang@sendbird.com'
   }
-  s.source       = { :http => "https://github.com/sendbird/sendbird-live-sdk-ios/releases/download/v1.2.0-beta.1/SendbirdLiveSDK.zip", :sha1 => "96b0d51ec185bb0856b5470d27fe38615c28f658" }
+  s.source       = { :http => "https://github.com/sendbird/sendbird-live-sdk-ios/releases/download/v1.2.0/SendbirdLiveSDK.zip", :sha1 => "8b508a4e8bbb512f9d603ee260f76a8ceeb41d09" }
   s.requires_arc = true
   s.platform = :ios, '11.0'
   s.documentation_url = 'https://sendbird.com/docs/live/v1/ios/ref/index.html'


### PR DESCRIPTION
- Added support for streaming with multiple hosts
    - Now, multiple hosts can stream in a live event simultaneously. 
    - `LiveEvent.hostType` has changed to `LiveEvent.type`
    - LiveEventType can have following values: `audioOnly` and `video`, indicating the live event type for audio-only streaming and video streaming, respectively. 
    - `LiveEventCreateParams.hostType` has changed to `LiveEventCreateParams.type`
    - `LiveEventQuery.hostTypes` has changed to `LiveEventQuery.types`
- Added event listeners for receiving connection
    - LiveEventDelegate.didDisconnect(liveEvent: LiveEvent, e: Error)
    - LiveEventDelegate.didReconnect(liveEvent: LiveEvent)
- The existing `didDisconnect` event is now renamed to `LiveEventDelegate.didExit(liveEvent: LiveEvent, e: Error)`
