### PR TITLE
Release 1.2.2

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 1.2.2 (Dec 18, 2023)
+- Added `LiveEvent.setVideoRendererForLiveEvent` to add video renderer to a specific host. 
+
 ## 1.2.1 (Dec 8, 2023)
 - Added `LiveEventDelegate.didHostVideoResolutionChange` to monitor changes in video resolution. 
 

--- a/Package.swift
+++ b/Package.swift
@@ -16,8 +16,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "SendbirdLiveSDK",
-            url: "https://github.com/sendbird/sendbird-live-sdk-ios/releases/download/v1.2.1/SendbirdLiveSDK.xcframework.zip",
-            checksum: "9f7fa2fd3b4f22c63d7af15d2747fc88caaf119d1b1ca74257b916c8466a598b"
+            url: "https://github.com/sendbird/sendbird-live-sdk-ios/releases/download/v1.2.2/SendbirdLiveSDK.xcframework.zip",
+            checksum: "f973ef249eb6e4f3b2109cf168c34f735eb700392e9da367f9b4bb4b427114ad"
         ),
         .target(name: "SendbirdLiveSDKTarget",
                 dependencies: [

--- a/SendbirdLiveSDK.podspec
+++ b/SendbirdLiveSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'SendbirdLiveSDK'
-  s.version      = "1.2.1"
+  s.version      = "1.2.2"
   s.summary      = 'Sendbird Live iOS Framework'
   s.description  = 'Sendbird Live API turns a client app into a live streaming platform where users can broadcast themselves in real-time to their followers.'
   s.homepage     = 'https://sendbird.com'
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
     'Celine Moon' => 'celine.moon@sendbird.com',
     'Young Hwang' => 'young.hwang@sendbird.com'
   }
-  s.source       = { :http => "https://github.com/sendbird/sendbird-live-sdk-ios/releases/download/v1.2.1/SendbirdLiveSDK.zip", :sha1 => "64d44cdfc073180f518614b2b3d619825a88839d" }
+  s.source       = { :http => "https://github.com/sendbird/sendbird-live-sdk-ios/releases/download/v1.2.2/SendbirdLiveSDK.zip", :sha1 => "3fc8c2e6f79c6d91fdcbb4d87ac8db5f91f4c20a" }
   s.requires_arc = true
   s.platform = :ios, '11.0'
   s.documentation_url = 'https://sendbird.com/docs/live/v1/ios/ref/index.html'


### PR DESCRIPTION
## 1.2.2 (Dec 18, 2023)
- Added `LiveEvent.setVideoRendererForLiveEvent` to add video renderer to a specific host. 
