### PR TITLE
Release 1.2.5

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 1.2.5 (Apr 4, 2024)
+* Updated iOS deployment target to 12.0
+* Updated Xcode version to 15.0
+* Added PrivacyInfo.xcprivacy for Apple Privacy Manifest
+
 ## 1.2.4 (Mar 21, 2024)
 - Improved WebRTC internal logging.
 

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@
 import PackageDescription
 let package = Package(
     name: "SendbirdLiveSDK",
-    platforms: [.iOS(.v11)],
+    platforms: [.iOS(.v12)],
     products: [
         .library(
             name: "SendbirdLiveSDK",
@@ -16,8 +16,8 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "SendbirdLiveSDK",
-            url: "https://github.com/sendbird/sendbird-live-sdk-ios/releases/download/v1.2.4/SendbirdLiveSDK.xcframework.zip",
-            checksum: "771f472c6acf7d51c4598d59eebb91ac0d56de5799d74354088eac2fde6a6921"
+            url: "https://github.com/sendbird/sendbird-live-sdk-ios/releases/download/v1.2.5/SendbirdLiveSDK.xcframework.zip",
+            checksum: "0693252ba3b43a1da1017e33ed3edc29cd5ad1a1d49662993c6c1b21b942e329"
         ),
         .target(name: "SendbirdLiveSDKTarget",
                 dependencies: [

--- a/SendbirdLiveSDK.podspec
+++ b/SendbirdLiveSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'SendbirdLiveSDK'
-  s.version      = "1.2.4"
+  s.version      = "1.2.5"
   s.summary      = 'Sendbird Live iOS Framework'
   s.description  = 'Sendbird Live API turns a client app into a live streaming platform where users can broadcast themselves in real-time to their followers.'
   s.homepage     = 'https://sendbird.com'
@@ -14,9 +14,9 @@ Pod::Spec.new do |s|
     'Celine Moon' => 'celine.moon@sendbird.com',
     'Young Hwang' => 'young.hwang@sendbird.com'
   }
-  s.source       = { :http => "https://github.com/sendbird/sendbird-live-sdk-ios/releases/download/v1.2.4/SendbirdLiveSDK.zip", :sha1 => "73cb55f3e641a15ae38b5cd02b4dbd2741395f73" }
+  s.source       = { :http => "https://github.com/sendbird/sendbird-live-sdk-ios/releases/download/v1.2.5/SendbirdLiveSDK.zip", :sha1 => "111c56fa400b03b72edce8a0bc2107163219d76a" }
   s.requires_arc = true
-  s.platform = :ios, '11.0'
+  s.platform = :ios, '12.0'
   s.documentation_url = 'https://sendbird.com/docs/live/v1/ios/ref/index.html'
   s.ios.vendored_frameworks = 'SendbirdLiveSDK/SendbirdLiveSDK.xcframework'
   s.dependency "SendBirdWebRTC", "~> 1.8.1"


### PR DESCRIPTION
## 1.2.5 (Apr 4, 2024)
* Updated iOS deployment target to 12.0
* Updated Xcode version to 15.0
* Added PrivacyInfo.xcprivacy for Apple Privacy Manifest
